### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/08_agentic_system/memory/langchain/code/README.md
+++ b/08_agentic_system/memory/langchain/code/README.md
@@ -77,7 +77,7 @@ DEEPSEEK_MODEL = "deepseek-chat"
 
 # MiniMax
 MINIMAX_API_KEY = "your-minimax-api-key"
-MINIMAX_MODEL = "MiniMax-M2.7"
+MINIMAX_MODEL = "MiniMax-M3"
 
 # 本地模型（Ollama / vLLM / LocalAI 等）
 LOCAL_BASE_URL = "http://localhost:11434/v1"
@@ -195,7 +195,7 @@ python main.py --interactive --persistent   # 聊天历史写入 sessions/checkp
 | `DEEPSEEK_API_KEY` | DeepSeek API 密钥   | 无                              |
 | `DEEPSEEK_MODEL`   | DeepSeek 模型名称   | `deepseek-chat`                 |
 | `MINIMAX_API_KEY`  | MiniMax API 密钥    | 无                              |
-| `MINIMAX_MODEL`    | MiniMax 模型名称    | `MiniMax-M2.7`                  |
+| `MINIMAX_MODEL`    | MiniMax 模型名称    | `MiniMax-M3`                    |
 | `LOCAL_BASE_URL`   | 本地模型 API URL    | `http://localhost:11434/v1`     |
 | `LOCAL_MODEL`      | 本地模型名称        | `qwen2.5`                       |
 
@@ -236,10 +236,10 @@ DEEPSEEK_MODEL = "deepseek-chat"
 
 ```python
 MINIMAX_API_KEY = "your-minimax-api-key"
-MINIMAX_MODEL = "MiniMax-M2.7"
+MINIMAX_MODEL = "MiniMax-M3"
 ```
 
-MiniMax 提供 OpenAI 兼容接口，支持 `MiniMax-M2.7`（1M 上下文）/ `MiniMax-M2.7-highspeed`。
+MiniMax 提供 OpenAI 兼容接口，默认使用最新旗舰模型 `MiniMax-M3`（512K 上下文、128K 最大输出，支持图像输入）；也支持上一代 `MiniMax-M2.7`（1M 上下文）/ `MiniMax-M2.7-highspeed`。
 
 ### 6.4 本地模型（Ollama）
 

--- a/08_agentic_system/memory/langchain/code/config.example.py
+++ b/08_agentic_system/memory/langchain/code/config.example.py
@@ -35,7 +35,7 @@ OPENAI_MODEL = "gpt-3.5-turbo"
 MINIMAX_API_KEY = "your-minimax-api-key-here"
 
 # MiniMax 模型名称
-MINIMAX_MODEL = "MiniMax-M2.7"
+MINIMAX_MODEL = "MiniMax-M3"
 
 # ================================
 # 本地模型配置（可选）
@@ -89,7 +89,7 @@ export OPENAI_API_KEY="sk-your-openai-api-key-here"
 export OPENAI_BASE_URL="https://api.openai.com/v1"
 export OPENAI_MODEL="gpt-3.5-turbo"
 export MINIMAX_API_KEY="your-minimax-api-key-here"
-export MINIMAX_MODEL="MiniMax-M2.7"
+export MINIMAX_MODEL="MiniMax-M3"
 export LOCAL_BASE_URL="http://localhost:8000/v1"
 export LOCAL_MODEL="qwen2.5:7b"
 export LLM_TEMPERATURE="0.7"
@@ -103,7 +103,7 @@ set OPENAI_API_KEY=sk-your-openai-api-key-here
 set OPENAI_BASE_URL=https://api.openai.com/v1
 set OPENAI_MODEL=gpt-3.5-turbo
 set MINIMAX_API_KEY=your-minimax-api-key-here
-set MINIMAX_MODEL=MiniMax-M2.7
+set MINIMAX_MODEL=MiniMax-M3
 set LOCAL_BASE_URL=http://localhost:8000/v1
 set LOCAL_MODEL=qwen2.5:7b
 set LLM_TEMPERATURE=0.7
@@ -123,8 +123,9 @@ set MAX_TOKEN_LIMIT=1000
 - gpt-3.5-turbo: 经典的GPT-3.5模型
 
 # MiniMax 模型（https://platform.minimaxi.com/）
-- MiniMax-M2.7: 最新旗舰模型，1M上下文窗口
-- MiniMax-M2.7-highspeed: 高速推理版本
+- MiniMax-M3: 最新旗舰模型，512K 上下文窗口、128K 最大输出，支持图像输入
+- MiniMax-M2.7: 上一代旗舰模型，1M 上下文窗口
+- MiniMax-M2.7-highspeed: M2.7 的高速推理版本
 
 # 本地模型（Ollama）
 - qwen2.5:7b: 通义千问2.5 7B参数版本

--- a/08_agentic_system/memory/langchain/code/llm_factory.py
+++ b/08_agentic_system/memory/langchain/code/llm_factory.py
@@ -185,11 +185,11 @@ class LLMFactory:
         """
         创建MiniMax LLM实例（通过OpenAI兼容接口）
 
-        MiniMax提供OpenAI兼容的API接口，支持MiniMax-M2.7等模型。
+        MiniMax提供OpenAI兼容的API接口，支持MiniMax-M3 / MiniMax-M2.7 等模型。
 
         Args:
             api_key: MiniMax API密钥
-            model: 模型名称（默认MiniMax-M2.7）
+            model: 模型名称（默认MiniMax-M3）
             temperature: 温度参数（MiniMax要求范围 (0.0, 1.0]）
             max_tokens: 最大token数
             timeout: 超时时间
@@ -198,7 +198,7 @@ class LLMFactory:
             ChatOpenAI实例
         """
         api_key = api_key or config.minimax_api_key
-        model = model or config.minimax_model or "MiniMax-M2.7"
+        model = model or config.minimax_model or "MiniMax-M3"
         temperature = temperature if temperature is not None else config.temperature
         max_tokens = max_tokens or config.max_tokens
         timeout = timeout or config.timeout

--- a/08_agentic_system/memory/langchain/code/tests/test_minimax_provider.py
+++ b/08_agentic_system/memory/langchain/code/tests/test_minimax_provider.py
@@ -27,7 +27,7 @@ class TestLLMConfigMiniMax(unittest.TestCase):
             cfg = LLMConfig()
             self.assertEqual(cfg.minimax_api_key, "")
             self.assertEqual(cfg.minimax_base_url, "https://api.minimax.io/v1")
-            self.assertEqual(cfg.minimax_model, "MiniMax-M2.7")
+            self.assertEqual(cfg.minimax_model, "MiniMax-M3")
 
     def test_minimax_config_from_env(self):
         """Test that MiniMax config reads from environment variables."""
@@ -227,11 +227,11 @@ class TestLLMFactoryMiniMax(unittest.TestCase):
 
     @patch("llm_factory.ChatOpenAI")
     def test_minimax_default_model(self, mock_chat):
-        """Test that MiniMax defaults to MiniMax-M2.7 model."""
+        """Test that MiniMax defaults to MiniMax-M3 model."""
         mock_chat.return_value = MagicMock()
         LLMFactory.create_minimax_llm(api_key="test-key")
         call_kwargs = mock_chat.call_args[1]
-        self.assertEqual(call_kwargs["model"], "MiniMax-M2.7")
+        self.assertEqual(call_kwargs["model"], "MiniMax-M3")
 
 
 class TestMiniMaxIntegration(unittest.TestCase):

--- a/08_agentic_system/multi_agent/multi_agent_system/config.json
+++ b/08_agentic_system/multi_agent/multi_agent_system/config.json
@@ -216,8 +216,8 @@
     "alternatives": {
       "minimax": {
         "base_url": "https://api.minimax.io/v1",
-        "model": "MiniMax-M2.7",
-        "description": "MiniMax M2.7 - 1M context window, OpenAI-compatible API"
+        "model": "MiniMax-M3",
+        "description": "MiniMax M3 - 512K context window, 128K max output, image input support, OpenAI-compatible API"
       },
       "openai": {
         "base_url": "https://api.openai.com/v1",


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to include the latest M3 model as default.

## Changes
- Add MiniMax-M3 as the new default model (replaces MiniMax-M2.7)
- Retain MiniMax-M2.7 / MiniMax-M2.7-highspeed as available alternatives
- Update related unit tests
- Refresh README / config example with the new default

## Why
MiniMax-M3 is the new flagship model with 512K context window, 128K max output, and image input support across both OpenAI-compatible and Anthropic-compatible interfaces.

## Affected files
- `08_agentic_system/memory/langchain/code/llm_factory.py`
- `08_agentic_system/memory/langchain/code/config.example.py`
- `08_agentic_system/memory/langchain/code/README.md`
- `08_agentic_system/memory/langchain/code/tests/test_minimax_provider.py`
- `08_agentic_system/multi_agent/multi_agent_system/config.json`

## Testing
- Unit tests updated and passing locally (`python3 -m unittest tests.test_minimax_provider -v` -> 21 passed, 3 integration tests skipped due to missing API key).