### PR TITLE
Fix customer service memory session isolation

### DIFF
--- a/08_agentic_system/memory/langchain/code/README.md
+++ b/08_agentic_system/memory/langchain/code/README.md
@@ -13,7 +13,7 @@
 | `ConversationSummaryMemory`       | 上面 + `summarize_node` + `RemoveMessage(...)`        | 长对话、成本敏感                  |
 | `ConversationSummaryBufferMemory` | `trim_messages` + `summarize_node`（两者组合）        | 生产默认：窗口控成本 + 摘要保记忆 |
 
-> 会话隔离不再需要自建 `memories: Dict[session_id, Memory]`；把 `session_id` 直接作为 LangGraph 的 `thread_id` 即可。
+> 会话隔离不再需要自建 `memories: Dict[session_id, Memory]`；把已校验的用户身份与 `session_id` 一起作为 LangGraph 的 `thread_id`，避免只凭裸 `session_id` 读写他人的记忆。
 >
 > **LangChain 1.x 安装说明**：从 LangChain **1.0** 起，上表 Legacy 列的类已从主包 `langchain` 迁出，转移至独立的 `langchain-classic` 包。本仓库的 `basic_memory_examples.py` 已将两种布局都兼容：优先导 `langchain_classic.memory`，失败后再回退到 `langchain.memory`。如果 pip 解析出的是 langchain 1.x，需额外安装 `pip install langchain-classic` 才能运行 Legacy 迁移参考 demo；仅运行 LangGraph demo 的话无需。
 
@@ -148,10 +148,10 @@ python main.py --demo basic
 
 已完全迁移到 LangGraph：
 
-- `SessionManager` 不再持有自己的 `memory` 字典；对话正文全部写进 checkpointer，键为 `thread_id = session_id`；
+- `SessionManager` 不再持有自己的 `memory` 字典；对话正文全部写进 checkpointer，键包含已校验的 `user_id`、`session_id` 与会话安全元数据；
 - `build_graph(memory_type)` 按 `buffer / window / summary_buffer` 三种策略编译三张图，公用一个 `MemorySaver`（默认）或 `SqliteSaver`（`--persistent`）；
 - `save_session` 只负责把 **会话元数据 + 性能指标** 写到 `sessions/*.json`，对话正文由 checkpointer 持久化；
-- 业务层 `CustomerServiceBot` 接口兼容旧版，`main.py` 不需要改动。
+- 业务层 `CustomerServiceBot` 调用时显式传入 `user_id`，`main.py` 已同步更新。
 
 ```bash
 python main.py --demo customer

--- a/08_agentic_system/memory/langchain/code/main.py
+++ b/08_agentic_system/memory/langchain/code/main.py
@@ -179,12 +179,12 @@ def run_interactive_chat(persistent: bool = False):
                     print(f"🤖 {welcome}")
                     continue
                 elif user_input.lower() in ['summary', '摘要']:
-                    summary = bot.get_conversation_summary(session_id)
+                    summary = bot.get_conversation_summary(user_id, session_id)
                     print(f"\n{summary}")
                     continue
                 
                 # 处理正常消息
-                result = bot.chat(session_id, user_input)
+                result = bot.chat(user_id, session_id, user_input)
                 
                 if "response" in result:
                     print(f"🤖 助手: {result['response']}")

--- a/08_agentic_system/memory/langchain/code/smart_customer_service.py
+++ b/08_agentic_system/memory/langchain/code/smart_customer_service.py
@@ -7,7 +7,7 @@
 全部迁移到 LangGraph：
     - StateGraph(MessagesState) 定义对话状态
     - MemorySaver / SqliteSaver 作为 checkpointer 实现短期记忆
-    - thread_id = session_id 实现多用户会话隔离
+    - thread_id 包含已校验的 user_id 与 session_id，实现多用户会话隔离
     - trim_messages 实现"窗口"策略
     - summarize_node + RemoveMessage 实现"摘要+窗口"策略
 
@@ -44,6 +44,7 @@ except ImportError:
 
 
 MemoryType = Literal["buffer", "window", "summary_buffer", "auto"]
+SECURITY_CONTEXT_METADATA_KEYS = ("tenant_id", "permissions")
 
 
 # ---------------------------------------------------------------------------
@@ -274,21 +275,75 @@ class SessionManager:
             return "window"
         return "summary_buffer"
 
+    def _get_authorized_session(self, user_id: str, session_id: str) -> SessionInfo:
+        if session_id not in self.sessions:
+            raise ValueError(f"会话不存在: {session_id}")
+        session_info = self.sessions[session_id]
+        if session_info.user_id != user_id:
+            raise PermissionError("当前用户无权访问该会话")
+        return session_info
+
+    def _validate_security_context(
+        self,
+        session_info: SessionInfo,
+        security_context: Optional[Dict[str, Any]],
+    ) -> None:
+        expected = {
+            key: session_info.metadata[key]
+            for key in SECURITY_CONTEXT_METADATA_KEYS
+            if key in session_info.metadata
+        }
+        if not expected:
+            return
+        provided = security_context or {}
+        for key, value in expected.items():
+            if provided.get(key) != value:
+                raise PermissionError("当前安全上下文无权访问该会话")
+
+    def _get_authorized_session_for_context(
+        self,
+        user_id: str,
+        session_id: str,
+        security_context: Optional[Dict[str, Any]] = None,
+    ) -> SessionInfo:
+        session_info = self._get_authorized_session(user_id, session_id)
+        self._validate_security_context(session_info, security_context)
+        return session_info
+
+    def _memory_thread_id(self, session_info: SessionInfo) -> str:
+        payload = {
+            "session_id": session_info.session_id,
+            "user_id": session_info.user_id,
+        }
+        for key in SECURITY_CONTEXT_METADATA_KEYS:
+            if key in session_info.metadata:
+                payload[key] = session_info.metadata[key]
+        return json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+
     # ------------------------------------------------------------------
     # 对话接口
     # ------------------------------------------------------------------
     def chat(
         self,
+        user_id: str,
         session_id: str,
         message: str,
         context: Optional[Dict[str, Any]] = None,
+        security_context: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        if session_id not in self.sessions:
-            raise ValueError(f"会话不存在: {session_id}")
+        session_info = self._get_authorized_session_for_context(
+            user_id, session_id, security_context
+        )
 
         start = time.time()
-        session_info = self.sessions[session_id]
         graph = self._graphs[session_info.memory_type]
+        thread_id = self._memory_thread_id(session_info)
 
         try:
             input_messages: List[Any] = []
@@ -303,7 +358,7 @@ class SessionManager:
 
             result = graph.invoke(
                 {"messages": input_messages},
-                config={"configurable": {"thread_id": session_id}},
+                config={"configurable": {"thread_id": thread_id}},
             )
             last_ai = next(
                 (m for m in reversed(result["messages"]) if isinstance(m, AIMessage)),
@@ -353,10 +408,18 @@ class SessionManager:
         if len(buf) > 100:
             del buf[:-100]
 
-    def get_session_info(self, session_id: str) -> Optional[Dict[str, Any]]:
-        if session_id not in self.sessions:
+    def get_session_info(
+        self,
+        user_id: str,
+        session_id: str,
+        security_context: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        try:
+            session_info = self._get_authorized_session_for_context(
+                user_id, session_id, security_context
+            )
+        except (PermissionError, ValueError):
             return None
-        session_info = self.sessions[session_id]
         metrics = self.performance_metrics.get(session_id, [])
         avg_rt = sum(m.response_time for m in metrics) / len(metrics) if metrics else 0
         avg_tk = sum(m.token_usage for m in metrics) / len(metrics) if metrics else 0
@@ -383,13 +446,20 @@ class SessionManager:
         ]
         return sorted(items, key=lambda x: x["last_active"], reverse=True)
 
-    def get_conversation_history(self, session_id: str) -> List[Dict[str, str]]:
-        """从 checkpointer 读取会话历史（不依赖 self.sessions 是否存在）。"""
-        memory_type = (
-            self.sessions[session_id].memory_type if session_id in self.sessions else "buffer"
+    def get_conversation_history(
+        self,
+        user_id: str,
+        session_id: str,
+        security_context: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, str]]:
+        """从 checkpointer 读取当前用户拥有的会话历史。"""
+        session_info = self._get_authorized_session_for_context(
+            user_id, session_id, security_context
         )
-        graph = self._graphs[memory_type]
-        state = graph.get_state({"configurable": {"thread_id": session_id}})
+        graph = self._graphs[session_info.memory_type]
+        state = graph.get_state(
+            {"configurable": {"thread_id": self._memory_thread_id(session_info)}}
+        )
         messages = (state.values or {}).get("messages", []) if state else []
         result = []
         for m in messages:
@@ -506,13 +576,30 @@ class CustomerServiceBot:
         )
         return session_id, welcome
 
-    def chat(self, session_id: str, message: str) -> Dict[str, Any]:
+    def chat(
+        self,
+        user_id: str,
+        session_id: str,
+        message: str,
+        security_context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         return self.session_manager.chat(
-            session_id, message, context={"系统角色": self.system_prompt}
+            user_id,
+            session_id,
+            message,
+            context={"系统角色": self.system_prompt},
+            security_context=security_context,
         )
 
-    def get_conversation_summary(self, session_id: str) -> str:
-        info = self.session_manager.get_session_info(session_id)
+    def get_conversation_summary(
+        self,
+        user_id: str,
+        session_id: str,
+        security_context: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        info = self.session_manager.get_session_info(
+            user_id, session_id, security_context
+        )
         if not info:
             return "会话不存在"
         s = info["session_info"]
@@ -572,7 +659,7 @@ def demo_customer_service(persistent: bool = False) -> None:
             user_name = next(u["name"] for u in users if u["user_id"] == user_id)
             sid = sessions[user_id]
             print(f"\n👤 {user_name}: {turns[r]}")
-            result = bot.chat(sid, turns[r])
+            result = bot.chat(user_id, sid, turns[r])
             if "response" in result:
                 print(f"🤖 客服: {result['response']}")
                 print(f"📊 响应时间: {result['response_time']:.2f}秒")
@@ -583,7 +670,10 @@ def demo_customer_service(persistent: bool = False) -> None:
     print("📋 会话摘要")
     print("=" * 50)
     for user in users:
-        print("\n" + bot.get_conversation_summary(sessions[user["user_id"]]))
+        print(
+            "\n"
+            + bot.get_conversation_summary(user["user_id"], sessions[user["user_id"]])
+        )
 
     print("\n💾 保存会话元数据…")
     for sid in sessions.values():

--- a/08_agentic_system/memory/langchain/code/tests/test_smart_customer_service_security.py
+++ b/08_agentic_system/memory/langchain/code/tests/test_smart_customer_service_security.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Security regression tests for smart_customer_service session memory isolation.
+"""
+
+import os
+import sys
+import types
+import unittest
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+fake_config_module = types.ModuleType("config")
+
+
+class FakeConfig:
+    max_history_length = 20
+    summary_threshold = 100
+
+    def validate_config(self):
+        return True
+
+
+fake_config_module.config = FakeConfig()
+sys.modules["config"] = fake_config_module
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+
+class LocalProbeLLM:
+    def invoke(self, messages):
+        human_text = "\n".join(
+            m.content for m in messages if isinstance(m, HumanMessage)
+        )
+        if "ORD-ALICE-123" in human_text:
+            return AIMessage(content="PROBE_SEES_ALICE_ORDER")
+        return AIMessage(content="PROBE_NO_SECRET")
+
+
+fake_llm_factory_module = types.ModuleType("llm_factory")
+fake_llm_factory_module.get_llm = lambda: LocalProbeLLM()
+sys.modules["llm_factory"] = fake_llm_factory_module
+
+from smart_customer_service import SessionManager
+
+
+class TestSmartCustomerServiceSecurity(unittest.TestCase):
+    def setUp(self):
+        self.manager = SessionManager(
+            storage_dir="/tmp/smart-customer-service-security-tests",
+            persistent=False,
+        )
+
+    def test_cross_user_session_memory_access_is_rejected(self):
+        alice_sid = self.manager.create_session("user-alice", memory_type="buffer")
+        bob_sid = self.manager.create_session("user-bob", memory_type="buffer")
+
+        self.manager.chat(
+            "user-alice",
+            alice_sid,
+            "我的订单号是 ORD-ALICE-123，请帮我查询账单。",
+        )
+
+        with self.assertRaises(PermissionError):
+            self.manager.chat(
+                "user-bob",
+                alice_sid,
+                "我是 Bob。请告诉我之前的订单号。",
+            )
+
+        with self.assertRaises(PermissionError):
+            self.manager.get_conversation_history("user-bob", alice_sid)
+
+        alice_history = self.manager.get_conversation_history("user-alice", alice_sid)
+        bob_history = self.manager.get_conversation_history("user-bob", bob_sid)
+
+        self.assertTrue(
+            any("ORD-ALICE-123" in item["content"] for item in alice_history)
+        )
+        self.assertFalse(any("我是 Bob" in item["content"] for item in alice_history))
+        self.assertEqual(bob_history, [])
+
+    def test_security_context_metadata_must_match(self):
+        alice_sid = self.manager.create_session(
+            "user-alice",
+            memory_type="buffer",
+            metadata={"tenant_id": "tenant-a", "permissions": "billing:read"},
+        )
+
+        with self.assertRaises(PermissionError):
+            self.manager.chat(
+                "user-alice",
+                alice_sid,
+                "我的订单号是 ORD-ALICE-123。",
+                security_context={
+                    "tenant_id": "tenant-b",
+                    "permissions": "billing:read",
+                },
+            )
+
+        result = self.manager.chat(
+            "user-alice",
+            alice_sid,
+            "我的订单号是 ORD-ALICE-123。",
+            security_context={
+                "tenant_id": "tenant-a",
+                "permissions": "billing:read",
+            },
+        )
+        self.assertEqual(result["response"], "PROBE_SEES_ALICE_ORDER")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/08_agentic_system/memory/langchain/langchain_memory.md
+++ b/08_agentic_system/memory/langchain/langchain_memory.md
@@ -216,7 +216,7 @@ with SqliteSaver.from_conn_string("./sessions/checkpoints.sqlite") as checkpoint
 | `ConversationSummaryMemory`       | 上面 + `summarize_node` + `RemoveMessage(...)`        | `demo_langgraph_summary`          |
 | `ConversationSummaryBufferMemory` | `trim_messages` + `summarize_node`（两者组合）        | `demo_langgraph_summary_buffer`   |
 
-会话隔离：把 `session_id` 直接塞进 `config={"configurable": {"thread_id": session_id}}`，不再需要自建 `memories: Dict[session_id, Memory]`。
+会话隔离：把已校验的用户身份与 `session_id` 一起放进 `config={"configurable": {"thread_id": thread_id}}`，不再需要自建 `memories: Dict[session_id, Memory]`。不要只用裸 `session_id` 作为记忆键，否则调用方拿到他人的会话标识后可能复用同一段记忆。
 
 ### 2.4 记忆类型选择指南
 
@@ -321,16 +321,17 @@ class SessionManager:
             "summary_buffer": build_graph("summary_buffer", self.llm, self.checkpointer),
         }
 
-    def chat(self, session_id: str, message: str, context=None):
-        info = self.sessions[session_id]
+    def chat(self, user_id: str, session_id: str, message: str, context=None):
+        info = self._get_authorized_session(user_id, session_id)
         graph = self._graphs[info.memory_type]
+        thread_id = self._memory_thread_id(info)
         input_messages = []
         if context:
             input_messages.append(SystemMessage("\n".join(f"{k}: {v}" for k, v in context.items())))
         input_messages.append(HumanMessage(message))
         result = graph.invoke(
             {"messages": input_messages},
-            config={"configurable": {"thread_id": session_id}},
+            config={"configurable": {"thread_id": thread_id}},
         )
         last_ai = next((m for m in reversed(result["messages"]) if isinstance(m, AIMessage)), None)
         # ……记录 response_time / token_usage / memory_size / last_active / message_count
@@ -339,7 +340,7 @@ class SessionManager:
 
 和老版最大的两点不同：
 
-1. 不再有 `self.memories: Dict[session_id, Memory]`——会话正文由 checkpointer 按 `thread_id` 自动隔离；
+1. 不再有 `self.memories: Dict[session_id, Memory]`——会话正文由 checkpointer 按包含用户身份的 `thread_id` 自动隔离；
 2. `save_session` 只负责把 `SessionInfo + PerformanceMetrics` 写到 `sessions/*.json`；`load_session` 只负责重建这些元数据。对话正文要么已经在 `MemorySaver` 的进程内字典里（重启即丢），要么已经在 `SqliteSaver` 的数据库里（重启后继续用同样的 `thread_id` 就能续上）。
 
 #### 3.2.3 自动选择记忆策略
@@ -363,10 +364,11 @@ def _auto_select_memory_type(self, user_id: str) -> str:
 
 #### 3.3.1 多用户会话隔离
 
-不再需要显式的"用户会话表"：把 `session_id` 作为 `thread_id` 传给 LangGraph 即可，不同用户之间的状态天然隔离；同一用户的不同会话也可以共用一张图，互不干扰。
+不再需要显式的正文记忆表：先校验 `session_id` 属于当前用户，再把用户身份与 `session_id` 共同作为 `thread_id` 传给 LangGraph。不同用户之间的状态天然隔离；同一用户的不同会话也可以共用一张图，互不干扰。
 
 ```python
-cfg = {"configurable": {"thread_id": session_id}}
+thread_id = f"{user_id}:{session_id}"
+cfg = {"configurable": {"thread_id": thread_id}}
 graph.invoke({"messages": [HumanMessage(user_input)]}, config=cfg)
 ```
 
@@ -542,7 +544,7 @@ python main.py --demo customer
 python main.py --demo customer --persistent   # 使用 SqliteSaver
 ```
 
-**功能说明**：模拟智能客服系统，展示多用户会话隔离（`thread_id = session_id`）、不同记忆策略（`buffer` / `window` / `summary_buffer`）下的响应时间与内存占用，并把会话元数据落盘到 `sessions/*.json`。
+**功能说明**：模拟智能客服系统，展示多用户会话隔离（`thread_id` 包含已校验的 `user_id` 与 `session_id`）、不同记忆策略（`buffer` / `window` / `summary_buffer`）下的响应时间与内存占用，并把会话元数据落盘到 `sessions/*.json`。
 
 **演示输出（节选）**：
 
@@ -644,7 +646,7 @@ python main.py --demo all
 
 ### 6.2 最佳实践建议
 
-1. **会话隔离用 `thread_id`**：不要再写 `Dict[session_id, Memory]` 这样的结构，把 `session_id`（或 `f"{user_id}:{session_id}"`) 直接放到 `config` 里；
+1. **会话隔离用 `thread_id`**：不要再写 `Dict[session_id, Memory]` 这样的结构；先校验会话归属，再把 `user_id`、`session_id` 以及必要的租户/权限上下文放到 `config` 的 `thread_id` 里；
 2. **窗口与摘要组合使用**：先 `trim_messages` 控本轮 prompt 长度，再用 `summarize_node + RemoveMessage` 控总体消息数；
 3. **摘要阈值要留 buffer**：`summarize_after` 建议是 `window_size + 2` 以上，避免"刚触发摘要、下轮又触发"导致的抖动；
 4. **生产环境用 `SqliteSaver` 起步**：本地、单机、跨进程都稳定，迁移到 `PostgresSaver` 只是改一行连接串；


### PR DESCRIPTION
## Summary
- require the current user id for customer service chat, summary, and history access
- validate tenant/permission security metadata when present before reading or writing memory
- derive LangGraph thread_id from the verified session security context instead of bare session_id
- update docs and add regression tests for cross-user memory recall and poisoning

## Tests
- /tmp/agentscan-langgraph-venv/bin/python -m unittest 08_agentic_system/memory/langchain/code/tests/test_smart_customer_service_security.py
- /tmp/agentscan-langgraph-venv/bin/python -m py_compile 08_agentic_system/memory/langchain/code/smart_customer_service.py 08_agentic_system/memory/langchain/code/main.py 08_agentic_system/memory/langchain/code/tests/test_smart_customer_service_security.py

Closes ForceInjection/AI-fundamentals#17