### PR TITLE
docs(readme): 修复 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **Star History**:
 
-![Star History Chart](https://api.star-history.com/svg?repos=ForceInjection/AI-fundamentals&type=date&legend=top-left)
+![Star History Chart](https://star-history.dera.page/svg?repos=ForceInjection/AI-fundamentals&type=date&legend=top-left)
 
 ---
 


### PR DESCRIPTION
当前 README 中的 Star History 图表因 GitHub stargazer API 限制已无法正常显示，本 PR 将其切换到新的图表服务域名以恢复图表展示。