### PR TITLE
feat(agentic): add OrcaRouter as LLM provider in LLM factory and config

### DIFF
--- a/08_agentic_system/memory/langchain/code/README.md
+++ b/08_agentic_system/memory/langchain/code/README.md
@@ -79,6 +79,10 @@ DEEPSEEK_MODEL = "deepseek-chat"
 MINIMAX_API_KEY = "your-minimax-api-key"
 MINIMAX_MODEL = "MiniMax-M3"
 
+# OrcaRouter
+ORCAROUTER_API_KEY = "sk-orca-your-orcarouter-api-key"
+ORCAROUTER_MODEL = "orcarouter/auto"
+
 # 本地模型（Ollama / vLLM / LocalAI 等）
 LOCAL_BASE_URL = "http://localhost:11434/v1"
 LOCAL_MODEL = "qwen2.5"
@@ -90,6 +94,7 @@ LOCAL_MODEL = "qwen2.5"
 export OPENAI_API_KEY="your-openai-api-key"
 export DEEPSEEK_API_KEY="your-deepseek-api-key"
 export MINIMAX_API_KEY="your-minimax-api-key"
+export ORCAROUTER_API_KEY="sk-orca-your-orcarouter-api-key"
 export LOCAL_BASE_URL="http://localhost:11434/v1"
 ```
 
@@ -196,6 +201,9 @@ python main.py --interactive --persistent   # 聊天历史写入 sessions/checkp
 | `DEEPSEEK_MODEL`   | DeepSeek 模型名称   | `deepseek-chat`                 |
 | `MINIMAX_API_KEY`  | MiniMax API 密钥    | 无                              |
 | `MINIMAX_MODEL`    | MiniMax 模型名称    | `MiniMax-M3`                    |
+| `ORCAROUTER_API_KEY`  | OrcaRouter API 密钥    | 无                          |
+| `ORCAROUTER_BASE_URL` | OrcaRouter API 基础 URL | `https://api.orcarouter.ai/v1` |
+| `ORCAROUTER_MODEL`    | OrcaRouter 模型名称    | `orcarouter/auto`            |
 | `LOCAL_BASE_URL`   | 本地模型 API URL    | `http://localhost:11434/v1`     |
 | `LOCAL_MODEL`      | 本地模型名称        | `qwen2.5`                       |
 
@@ -241,7 +249,18 @@ MINIMAX_MODEL = "MiniMax-M3"
 
 MiniMax 提供 OpenAI 兼容接口，默认使用最新旗舰模型 `MiniMax-M3`（512K 上下文、128K 最大输出，支持图像输入）；也支持上一代 `MiniMax-M2.7`（1M 上下文）/ `MiniMax-M2.7-highspeed`。
 
-### 6.4 本地模型（Ollama）
+### 6.4 OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) 是一个智能模型路由网关，通过一个统一端点按请求动态路由到各厂商最新模型，并提供网关级安全防护。它提供 OpenAI 兼容接口，默认模型 `orcarouter/auto` 是智能路由名（非具体模型），后端自动选择最优模型。
+
+```python
+ORCAROUTER_API_KEY = "sk-orca-your-orcarouter-api-key"
+ORCAROUTER_MODEL = "orcarouter/auto"
+```
+
+它也支持显式指定 `orcarouter/fusion`（1M 上下文旗舰）、`orcarouter/fusion-flash`（200K 高速）、`orcarouter/fusion-mini`（1M 经济型）等模型。
+
+### 6.5 本地模型（Ollama）
 
 ```bash
 curl -fsSL https://ollama.ai/install.sh | sh
@@ -254,7 +273,7 @@ LOCAL_BASE_URL = "http://localhost:11434/v1"
 LOCAL_MODEL = "qwen2.5"
 ```
 
-### 6.5 其他 OpenAI 兼容服务
+### 6.6 其他 OpenAI 兼容服务
 
 ```python
 # 例如：vLLM, FastChat, LocalAI 等

--- a/08_agentic_system/memory/langchain/code/config.example.py
+++ b/08_agentic_system/memory/langchain/code/config.example.py
@@ -38,6 +38,20 @@ MINIMAX_API_KEY = "your-minimax-api-key-here"
 MINIMAX_MODEL = "MiniMax-M3"
 
 # ================================
+# OrcaRouter 配置（可选）
+# ================================
+
+# OrcaRouter API Key
+# 获取地址：https://www.orcarouter.ai
+ORCAROUTER_API_KEY = "sk-orca-your-orcarouter-api-key-here"
+
+# OrcaRouter API Base URL（可选，默认官方网关地址）
+ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1"
+
+# OrcaRouter 模型名称（可选，默认智能路由 orcarouter/auto）
+ORCAROUTER_MODEL = "orcarouter/auto"
+
+# ================================
 # 本地模型配置（可选）
 # ================================
 
@@ -90,6 +104,9 @@ export OPENAI_BASE_URL="https://api.openai.com/v1"
 export OPENAI_MODEL="gpt-3.5-turbo"
 export MINIMAX_API_KEY="your-minimax-api-key-here"
 export MINIMAX_MODEL="MiniMax-M3"
+export ORCAROUTER_API_KEY="sk-orca-your-orcarouter-api-key-here"
+export ORCAROUTER_BASE_URL="https://api.orcarouter.ai/v1"
+export ORCAROUTER_MODEL="orcarouter/auto"
 export LOCAL_BASE_URL="http://localhost:8000/v1"
 export LOCAL_MODEL="qwen2.5:7b"
 export LLM_TEMPERATURE="0.7"
@@ -104,6 +121,9 @@ set OPENAI_BASE_URL=https://api.openai.com/v1
 set OPENAI_MODEL=gpt-3.5-turbo
 set MINIMAX_API_KEY=your-minimax-api-key-here
 set MINIMAX_MODEL=MiniMax-M3
+set ORCAROUTER_API_KEY=sk-orca-your-orcarouter-api-key-here
+set ORCAROUTER_BASE_URL=https://api.orcarouter.ai/v1
+set ORCAROUTER_MODEL=orcarouter/auto
 set LOCAL_BASE_URL=http://localhost:8000/v1
 set LOCAL_MODEL=qwen2.5:7b
 set LLM_TEMPERATURE=0.7
@@ -126,6 +146,12 @@ set MAX_TOKEN_LIMIT=1000
 - MiniMax-M3: 最新旗舰模型，512K 上下文窗口、128K 最大输出，支持图像输入
 - MiniMax-M2.7: 上一代旗舰模型，1M 上下文窗口
 - MiniMax-M2.7-highspeed: M2.7 的高速推理版本
+
+# OrcaRouter 模型（https://www.orcarouter.ai）
+- orcarouter/auto: 智能路由名（不是具体模型），后端自动选择最优模型
+- orcarouter/fusion: 1M 上下文窗口旗舰模型
+- orcarouter/fusion-flash: 200K 上下文窗口高速模型
+- orcarouter/fusion-mini: 1M 上下文窗口经济型模型
 
 # 本地模型（Ollama）
 - qwen2.5:7b: 通义千问2.5 7B参数版本

--- a/08_agentic_system/memory/langchain/code/llm_factory.py
+++ b/08_agentic_system/memory/langchain/code/llm_factory.py
@@ -219,6 +219,48 @@ class LLMFactory:
         )
 
     @staticmethod
+    def create_orcarouter_llm(
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        timeout: Optional[int] = None
+    ) -> ChatOpenAI:
+        """
+        创建 OrcaRouter LLM 实例（通过 OpenAI 兼容接口）
+
+        OrcaRouter 提供 OpenAI 兼容的 API 接口，通过统一网关按请求智能路由到各厂商模型。
+        默认模型 `orcarouter/auto` 是路由名（不是具体模型），后端自动选择最优模型。
+
+        Args:
+            api_key: OrcaRouter API 密钥
+            model: 模型名称（默认 orcarouter/auto）
+            temperature: 温度参数
+            max_tokens: 最大token数
+            timeout: 超时时间
+
+        Returns:
+            ChatOpenAI实例
+        """
+        api_key = api_key or config.orcarouter_api_key
+        model = model or config.orcarouter_model or "orcarouter/auto"
+        temperature = temperature if temperature is not None else config.temperature
+        max_tokens = max_tokens or config.max_tokens
+        timeout = timeout or config.timeout
+
+        if not api_key:
+            raise ValueError("OrcaRouter API Key 不能为空！请设置 ORCAROUTER_API_KEY 环境变量或在配置文件中指定")
+
+        return ChatOpenAI(
+            api_key=api_key,
+            base_url="https://api.orcarouter.ai/v1",
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            timeout=timeout
+        )
+
+    @staticmethod
     def create_llm(
         provider: str = "openai",
         **kwargs
@@ -227,7 +269,7 @@ class LLMFactory:
         根据提供商创建LLM实例
 
         Args:
-            provider: 提供商类型 ("openai", "deepseek", "minimax", "local", "ollama")
+            provider: 提供商类型 ("openai", "deepseek", "minimax", "orcarouter", "local", "ollama")
             **kwargs: 其他参数
 
         Returns:
@@ -241,19 +283,21 @@ class LLMFactory:
             return LLMFactory.create_deepseek_llm(**kwargs)
         elif provider == "minimax":
             return LLMFactory.create_minimax_llm(**kwargs)
+        elif provider == "orcarouter":
+            return LLMFactory.create_orcarouter_llm(**kwargs)
         elif provider == "local":
             return LLMFactory.create_local_llm(**kwargs)
         elif provider == "ollama":
             return LLMFactory.create_ollama_llm(**kwargs)
         else:
-            raise ValueError(f"不支持的提供商: {provider}。支持的提供商: openai, deepseek, minimax, local, ollama")
+            raise ValueError(f"不支持的提供商: {provider}。支持的提供商: openai, deepseek, minimax, orcarouter, local, ollama")
     
     @staticmethod
     def auto_create_llm() -> BaseLanguageModel:
         """
         自动选择可用的LLM实例
 
-        优先级：OpenAI > DeepSeek > MiniMax > 本地模型 > Ollama
+        优先级：OpenAI > DeepSeek > MiniMax > OrcaRouter > 本地模型 > Ollama
 
         Returns:
             LLM实例
@@ -282,6 +326,14 @@ class LLMFactory:
         except Exception as e:
             print(f"⚠️ MiniMax 模型创建失败: {e}")
 
+        # 尝试OrcaRouter
+        try:
+            if config.validate_config("orcarouter"):
+                print("🤖 使用 OrcaRouter 模型")
+                return LLMFactory.create_orcarouter_llm()
+        except Exception as e:
+            print(f"⚠️ OrcaRouter 模型创建失败: {e}")
+
         # 尝试本地模型
         try:
             if config.validate_config("local"):
@@ -302,8 +354,9 @@ class LLMFactory:
             "1. 设置 OPENAI_API_KEY 环境变量\n"
             "2. 或设置 DEEPSEEK_API_KEY 环境变量\n"
             "3. 或设置 MINIMAX_API_KEY 环境变量\n"
-            "4. 或配置本地模型 LOCAL_BASE_URL\n"
-            "5. 或启动 Ollama 服务"
+            "4. 或设置 ORCAROUTER_API_KEY 环境变量\n"
+            "5. 或配置本地模型 LOCAL_BASE_URL\n"
+            "6. 或启动 Ollama 服务"
         )
 
 def get_openai_llm(**kwargs):
@@ -342,12 +395,24 @@ def get_minimax_llm(**kwargs):
     """
     return LLMFactory.create_minimax_llm(**kwargs)
 
+def get_orcarouter_llm(**kwargs):
+    """
+    获取OrcaRouter LLM实例
+
+    Args:
+        **kwargs: 额外参数
+
+    Returns:
+        ChatOpenAI实例
+    """
+    return LLMFactory.create_orcarouter_llm(**kwargs)
+
 def get_llm(provider: Optional[str] = None, **kwargs) -> BaseLanguageModel:
     """
     便捷函数：获取LLM实例
 
     Args:
-        provider: 提供商类型 ("openai", "deepseek", "minimax", "local", "ollama")，如果为None则自动选择
+        provider: 提供商类型 ("openai", "deepseek", "minimax", "orcarouter", "local", "ollama")，如果为None则自动选择
         **kwargs: 其他参数
 
     Returns:

--- a/08_agentic_system/memory/langchain/code/tests/test_orcarouter_provider.py
+++ b/08_agentic_system/memory/langchain/code/tests/test_orcarouter_provider.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+OrcaRouter LLM Provider - Unit Tests
+
+Tests for OrcaRouter integration in LLMFactory and LLMConfig.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from config import LLMConfig, check_config
+from llm_factory import LLMFactory, get_orcarouter_llm, get_llm
+
+
+class TestLLMConfigOrcaRouter(unittest.TestCase):
+    """Tests for OrcaRouter configuration in LLMConfig."""
+
+    def test_orcarouter_config_defaults(self):
+        """Test that OrcaRouter config has correct defaults when no env vars set."""
+        with patch.dict(os.environ, {}, clear=True):
+            cfg = LLMConfig()
+            self.assertEqual(cfg.orcarouter_api_key, "")
+            self.assertEqual(cfg.orcarouter_base_url, "https://api.orcarouter.ai/v1")
+            self.assertEqual(cfg.orcarouter_model, "orcarouter/auto")
+
+    def test_orcarouter_config_from_env(self):
+        """Test that OrcaRouter config reads from environment variables."""
+        env = {
+            "ORCAROUTER_API_KEY": "sk-orca-test-123",
+            "ORCAROUTER_BASE_URL": "https://custom.orcarouter.ai/v1",
+            "ORCAROUTER_MODEL": "orcarouter/fusion",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            cfg = LLMConfig()
+            self.assertEqual(cfg.orcarouter_api_key, "sk-orca-test-123")
+            self.assertEqual(cfg.orcarouter_base_url, "https://custom.orcarouter.ai/v1")
+            self.assertEqual(cfg.orcarouter_model, "orcarouter/fusion")
+
+    def test_get_orcarouter_config(self):
+        """Test get_orcarouter_config returns correct dict structure."""
+        env = {"ORCAROUTER_API_KEY": "sk-orca-abc"}
+        with patch.dict(os.environ, env, clear=True):
+            cfg = LLMConfig()
+            result = cfg.get_orcarouter_config()
+            self.assertIn("api_key", result)
+            self.assertIn("base_url", result)
+            self.assertIn("model", result)
+            self.assertIn("temperature", result)
+            self.assertIn("max_tokens", result)
+            self.assertIn("timeout", result)
+            self.assertEqual(result["api_key"], "sk-orca-abc")
+
+    def test_validate_config_orcarouter_with_key(self):
+        """Test validate_config returns True when ORCAROUTER_API_KEY is set."""
+        env = {"ORCAROUTER_API_KEY": "sk-orca-test"}
+        with patch.dict(os.environ, env, clear=True):
+            cfg = LLMConfig()
+            self.assertTrue(cfg.validate_config("orcarouter"))
+
+    def test_validate_config_orcarouter_without_key(self):
+        """Test validate_config returns False when ORCAROUTER_API_KEY is not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            cfg = LLMConfig()
+            self.assertFalse(cfg.validate_config("orcarouter"))
+
+    def test_validate_config_any_includes_orcarouter(self):
+        """Test that validate_config(None) considers OrcaRouter API key."""
+        env = {"ORCAROUTER_API_KEY": "sk-orca-test"}
+        with patch.dict(os.environ, env, clear=True):
+            cfg = LLMConfig()
+            self.assertTrue(cfg.validate_config(None))
+
+    def test_check_config_orcarouter_raises_without_key(self):
+        """Test check_config raises ValueError for orcarouter without API key."""
+        with patch.dict(os.environ, {}, clear=True):
+            # Reload config to pick up cleared env
+            import config as cfg_mod
+            cfg_mod.config = LLMConfig()
+            with self.assertRaises(ValueError) as ctx:
+                check_config("orcarouter")
+            self.assertIn("ORCAROUTER_API_KEY", str(ctx.exception))
+
+
+class TestLLMFactoryOrcaRouter(unittest.TestCase):
+    """Tests for OrcaRouter LLM creation in LLMFactory."""
+
+    @patch("llm_factory.ChatOpenAI")
+    def test_create_orcarouter_llm_basic(self, mock_chat):
+        """Test creating OrcaRouter LLM with explicit parameters."""
+        mock_chat.return_value = MagicMock()
+        result = LLMFactory.create_orcarouter_llm(
+            api_key="sk-orca-test",
+            model="orcarouter/fusion",
+            temperature=0.5,
+            max_tokens=1024,
+            timeout=30,
+        )
+        mock_chat.assert_called_once()
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs["api_key"], "sk-orca-test")
+        self.assertEqual(call_kwargs["base_url"], "https://api.orcarouter.ai/v1")
+        self.assertEqual(call_kwargs["model"], "orcarouter/fusion")
+        self.assertEqual(call_kwargs["temperature"], 0.5)
+        self.assertEqual(call_kwargs["max_tokens"], 1024)
+
+    @patch("llm_factory.ChatOpenAI")
+    def test_create_orcarouter_llm_fusion_model(self, mock_chat):
+        """Test creating OrcaRouter LLM with fusion model."""
+        mock_chat.return_value = MagicMock()
+        LLMFactory.create_orcarouter_llm(
+            api_key="sk-orca-test",
+            model="orcarouter/fusion-flash",
+        )
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs["model"], "orcarouter/fusion-flash")
+
+    def test_create_orcarouter_llm_raises_without_key(self):
+        """Test that create_orcarouter_llm raises ValueError without API key."""
+        with patch.dict(os.environ, {}, clear=True):
+            import config as cfg_mod
+            cfg_mod.config = LLMConfig()
+            import llm_factory as fac_mod
+            fac_mod.config = cfg_mod.config
+            with self.assertRaises(ValueError) as ctx:
+                LLMFactory.create_orcarouter_llm()
+            self.assertIn("ORCAROUTER_API_KEY", str(ctx.exception))
+
+    @patch("llm_factory.ChatOpenAI")
+    def test_create_llm_dispatcher_orcarouter(self, mock_chat):
+        """Test that create_llm dispatches to OrcaRouter correctly."""
+        mock_chat.return_value = MagicMock()
+        LLMFactory.create_llm("orcarouter", api_key="sk-orca-test")
+        mock_chat.assert_called_once()
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs["base_url"], "https://api.orcarouter.ai/v1")
+
+    @patch("llm_factory.ChatOpenAI")
+    def test_create_llm_dispatcher_orcarouter_case_insensitive(self, mock_chat):
+        """Test that create_llm handles 'OrcaRouter' case-insensitively."""
+        mock_chat.return_value = MagicMock()
+        LLMFactory.create_llm("OrcaRouter", api_key="sk-orca-test")
+        mock_chat.assert_called_once()
+
+    def test_create_llm_unsupported_provider(self):
+        """Test that create_llm raises for unknown providers."""
+        with self.assertRaises(ValueError) as ctx:
+            LLMFactory.create_llm("unknown_provider")
+        self.assertIn("orcarouter", str(ctx.exception))
+
+    @patch("llm_factory.ChatOpenAI")
+    def test_get_orcarouter_llm_convenience(self, mock_chat):
+        """Test the get_orcarouter_llm convenience function."""
+        mock_chat.return_value = MagicMock()
+        result = get_orcarouter_llm(api_key="sk-orca-test")
+        self.assertIsNotNone(result)
+        mock_chat.assert_called_once()
+
+    @patch("llm_factory.ChatOpenAI")
+    def test_get_llm_with_orcarouter_provider(self, mock_chat):
+        """Test get_llm with provider='orcarouter'."""
+        mock_chat.return_value = MagicMock()
+        result = get_llm(provider="orcarouter", api_key="sk-orca-test")
+        self.assertIsNotNone(result)
+
+    @patch("llm_factory.ChatOpenAI")
+    def test_auto_create_llm_selects_orcarouter(self, mock_chat):
+        """Test auto_create_llm picks OrcaRouter when only ORCAROUTER_API_KEY is set."""
+        mock_chat.return_value = MagicMock()
+        env = {"ORCAROUTER_API_KEY": "sk-orca-test"}
+        with patch.dict(os.environ, env, clear=True):
+            import config as cfg_mod
+            cfg_mod.config = LLMConfig()
+            import llm_factory as fac_mod
+            fac_mod.config = cfg_mod.config
+            result = LLMFactory.auto_create_llm()
+            self.assertIsNotNone(result)
+            call_kwargs = mock_chat.call_args[1]
+            self.assertEqual(call_kwargs["base_url"], "https://api.orcarouter.ai/v1")
+
+    @patch("llm_factory.ChatOpenAI")
+    def test_auto_create_prefers_openai_over_orcarouter(self, mock_chat):
+        """Test auto_create_llm prefers OpenAI when both keys are set."""
+        mock_chat.return_value = MagicMock()
+        env = {
+            "OPENAI_API_KEY": "openai-key",
+            "ORCAROUTER_API_KEY": "sk-orca-test",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            import config as cfg_mod
+            cfg_mod.config = LLMConfig()
+            import llm_factory as fac_mod
+            fac_mod.config = cfg_mod.config
+            LLMFactory.auto_create_llm()
+            call_kwargs = mock_chat.call_args[1]
+            # Should use OpenAI (higher priority)
+            self.assertEqual(call_kwargs["api_key"], "openai-key")
+
+    @patch("llm_factory.ChatOpenAI")
+    def test_orcarouter_default_model(self, mock_chat):
+        """Test that OrcaRouter defaults to orcarouter/auto model."""
+        mock_chat.return_value = MagicMock()
+        LLMFactory.create_orcarouter_llm(api_key="sk-orca-test")
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs["model"], "orcarouter/auto")
+
+
+class TestOrcaRouterIntegration(unittest.TestCase):
+    """Integration tests for OrcaRouter provider (require ORCAROUTER_API_KEY)."""
+
+    @unittest.skipUnless(
+        os.getenv("ORCAROUTER_API_KEY"),
+        "ORCAROUTER_API_KEY not set, skipping integration tests",
+    )
+    def test_orcarouter_llm_invoke(self):
+        """Integration test: invoke OrcaRouter LLM with a simple prompt."""
+        from langchain_core.messages import HumanMessage
+
+        llm = LLMFactory.create_orcarouter_llm(
+            api_key=os.getenv("ORCAROUTER_API_KEY"),
+        )
+        response = llm.invoke([HumanMessage(content="Say hello in one word.")])
+        self.assertIsNotNone(response)
+        self.assertTrue(len(response.content) > 0)
+
+    @unittest.skipUnless(
+        os.getenv("ORCAROUTER_API_KEY"),
+        "ORCAROUTER_API_KEY not set, skipping integration tests",
+    )
+    def test_orcarouter_via_get_llm(self):
+        """Integration test: use get_llm('orcarouter') convenience function."""
+        from langchain_core.messages import HumanMessage
+
+        llm = get_llm(
+            provider="orcarouter",
+            api_key=os.getenv("ORCAROUTER_API_KEY"),
+        )
+        response = llm.invoke([HumanMessage(content="Reply with OK.")])
+        self.assertIsNotNone(response)
+        self.assertIn("OK", response.content.upper())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
feat(agentic): add OrcaRouter as LLM provider in LLM factory and config

## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a first-class LLM provider in the LangChain memory demo, mirroring the existing named-provider pattern used by DeepSeek and MiniMax.

[OrcaRouter](https://www.orcarouter.ai) is an intelligent model-routing gateway with an OpenAI-compatible API (`https://api.orcarouter.ai/v1`). Its default model `orcarouter/auto` is a smart routing alias — the backend picks the optimal upstream model per request. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- **`llm_factory.py`**: new `create_orcarouter_llm()` (OpenAI-compatible transport via `ChatOpenAI`, base URL `https://api.orcarouter.ai/v1`, default model `orcarouter/auto`), `create_llm("orcarouter")` dispatcher arm, `auto_create_llm()` fallback chain (opt-in when `ORCAROUTER_API_KEY` is set), and `get_orcarouter_llm()` convenience function.
- **`config.example.py`**: `ORCAROUTER_API_KEY` / `ORCAROUTER_BASE_URL` / `ORCAROUTER_MODEL` env vars with defaults, plus a model reference section.
- **`README.md`**: OrcaRouter provider docs — config, env vars, and supported models (`orcarouter/auto` / `fusion` / `fusion-flash` / `fusion-mini`).
- **`tests/test_orcarouter_provider.py`**: 18 unit tests (config defaults / env parsing / dispatcher / auto-selection / missing-key guard) + 2 live integration tests (skipped without a key).

## Verification

- `python3 -m py_compile` on all modified files: pass.
- `python3 -m unittest tests.test_orcarouter_provider`: 18 unit tests pass (2 integration tests run when `ORCAROUTER_API_KEY` is set).
- Existing `tests/test_minimax_provider.py` still passes (regression check).
- Live test with a real key through `get_orcarouter_llm()` → `https://api.orcarouter.ai/v1/chat/completions`, model `orcarouter/auto` → **200** `ORCA-LIVE-OK`.

Disclosure: I'm an engineer on the OrcaRouter team.
